### PR TITLE
Fixes: antivirus false positive, GoG detection, install directory mismanagment

### DIFF
--- a/config/icons.iss
+++ b/config/icons.iss
@@ -1,12 +1,13 @@
 [Icons]
 // Desktop icons
-Name: "{autodesktop}\MMH5.6 (64bit)";          Filename: "{app}\bin\MMH55_64.exe";
-Name: "{autodesktop}\MMH5.6 Editor (64bit)";   Filename: "{app}\bin\MMH55_Editor_64.exe";
+Name: "{autodesktop}\MMH5.5 (64bit)";          Filename: "{app}\bin\MMH55_64.exe";
+Name: "{autodesktop}\MMH5.5 Editor (64bit)";   Filename: "{app}\bin\MMH55_Editor_64.exe";
 // StartMenu icons
-Name: "{group}\MMH5.6 Play";                   Filename: "{app}\bin\MMH55.exe"
-Name: "{group}\MMH5.6 Play (64bit)";           Filename: "{app}\bin\MMH55_64.exe"
-Name: "{group}\MMH5.6 Utility (ARMG)";         Filename: "{app}\bin\MMH55_Utility.exe"
-Name: "{group}\MMH5.6 Utility (64bit) (ARMG)"; Filename: "{app}\bin\MMH55_Utility_64.exe"
-Name: "{group}\MMH5.6 Editor (ARMG)";          Filename: "{app}\bin\MMH55_Editor.exe"
-Name: "{group}\MMH5.6 Editor (64bit) (ARMG)";  Filename: "{app}\bin\MMH55_Editor_64.exe"
-Name: "{group}\MMH5.6 Uninstall";              Filename: "{app}\unins000.exe"
+Name: "{group}\MMH5.5 Play";                   Filename: "{app}\bin\MMH55.exe"
+Name: "{group}\MMH5.5 Play (64bit)";           Filename: "{app}\bin\MMH55_64.exe"
+Name: "{group}\MMH5.5 Utility (ARMG)";         Filename: "{app}\bin\MMH55_Utility.exe"
+Name: "{group}\MMH5.5 Utility (64bit) (ARMG)"; Filename: "{app}\bin\MMH55_Utility_64.exe"
+Name: "{group}\MMH5.5 Editor (ARMG)";          Filename: "{app}\bin\MMH55_Editor.exe"
+Name: "{group}\MMH5.5 Editor (64bit) (ARMG)";  Filename: "{app}\bin\MMH55_Editor_64.exe"
+Name: "{group}\MMH5.5 Uninstall";              Filename: "{app}\unins000.exe"
+Name: "{group}\MMH5.5 ARMG Manual";            Filename: "{app}\ARMG Manual V2.7.pdf"

--- a/config/variables.iss
+++ b/config/variables.iss
@@ -1,10 +1,10 @@
 // Application variables
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-#define APP_ID        "55EA9482-ECB1-439D-951C-798B8CC2D68D"
-#define APP_Name      "Might & Magic Heroes 5.6"
-#define APP_StartName "Might & Magic - Heroes 5.6"
-#define APP_Version   "RC19f"
+#define APP_ID        "CEC93C99-EB3D-4EBE-B0BE-AE228E5B47AE"
+#define APP_Name      "Might & Magic Heroes 5.5"
+#define APP_StartName "Might & Magic - Heroes 5.5"
+#define APP_Version   "RC19e"
 #define APP_Publisher "MMH55 team"
 #define APP_URL       "https://www.moddb.com/mods/might-magic-heroes-55"
 #define APP_Support   "https://discord.gg/khKPUrKxC4"

--- a/main.iss
+++ b/main.iss
@@ -7,7 +7,7 @@
 #define C_REGISTRY_TOE_CD    'SOFTWARE\WOW6432Node\Ubisoft\Heroes of Might and Magic V - Tribes of the East';
 
 // GOG
-#define C_REGISTRY_TOE_GOG   'SOFTWARE\GOG.com\Games';
+#define C_REGISTRY_TOE_GOG   'SOFTWARE\WOW6432Node\GOG.com\Games';
 
 // Steam
 #define C_REGISTRY_STEAM     'SOFTWARE\WOW6432Node\Valve\Steam';
@@ -74,6 +74,7 @@ begin
   begin
     for I := 0 to GetArrayLength(SubkeyNames) - 1 do
     begin
+      //Log('This is a debug message.' + SubkeyNames[I]);
       if RegQueryStringValue(RootKey, Subkey + '\' + SubkeyNames[I], 'InstallPath', InstallPath) then
       begin
         Result := InstallPath;
@@ -143,13 +144,16 @@ DefaultDirName={code:GetOtherAppPath|{#C_PATH_TOE_DEFAULT}}
 DefaultGroupName={#APP_StartName}
 OutputDir=output
 OutputBaseFilename={#APP_SetupName}
-Compression=lzma
+Compression=none
 SolidCompression=yes
 WizardStyle=modern
 DirExistsWarning=no
 UninstallDisplayName={#APP_Name}
 DisableWelcomePage=no
 AppendDefaultDirName=no
+AllowRootDirectory=yes
+UsePreviousAppDir=no
+
 //Texts
 InfoBeforeFile=config/texts/information.txt
 //Images


### PR DESCRIPTION
- Removed payload compression which was made the installer to be flagged as virus by antivirus systems. This will make the size of the package grow about 10%.
- fixed a corner case where the installer was not showing the destination path during installation which prevented the user to install the mod more then once
- fixed: detection of GOG Heroes V installation not working due to the new registry paths after the GOG v2.0 release
- fixed some 5.5 descriptions